### PR TITLE
Device Info Route and Testing

### DIFF
--- a/routes/device/GET-info.js
+++ b/routes/device/GET-info.js
@@ -1,9 +1,21 @@
+const Device = require('../../models/device');
 module.exports = (app, db) => {
   app.get('/device/info', (req, res, next) => {
     // TODO
     // INPUT: API key
     // the device information is provided
-    // OUTPUT: firendly name
-    res.sendStatus(404);
+    // OUTPUT: friendly name
+    const apiKey = req.body.apiKey;
+    Device.findOne({apiKey: apiKey}, 'friendlyName', function (err, foundDevice) {
+      if (err) {
+        return res.status(400);
+      }
+      else if (foundDevice == null) {
+        return res.status(404);
+      }
+      else {
+        return res.status(200).json({ friendlyName: foundDevice.friendlyName });
+      }
+    });
   });
 }

--- a/test/device_info_test.js
+++ b/test/device_info_test.js
@@ -3,16 +3,36 @@ const chai = require('chai');
 const { assert } = require('chai');
 const mongoose = require('mongoose');
 const server = require('../app');
-const app = require('../app');
+const faker = require('faker');
+const uuidApiKey = require('uuid-apikey');
+const Device = require('../models/device');
 
 chai.use(chaiHttp);
 
+const temp_mac = faker.internet.mac();
+const temp_name = faker.internet.userName();
+const { uuid, apiKey } = uuidApiKey.create();
+
+//register a temp device
+new mongoose.model('Device') ({
+  deviceId: temp_mac,
+  friendlyName: temp_name,
+  uuid: uuid,
+  apiKey: apiKey,
+}).save();
+    
+//test
 describe('/GET device/info', () => {
   it('it should GET the information', (done) => {
     chai.request(server)
       .get('/device/info')
+      .send({apiKey: apiKey})
       .end((err, res) => {
         assert.equal(res.statusCode, 200);
+        done();
       });
   });
 });
+
+//delete temp device
+Device.deleteOne({ deviceId: temp_mac });


### PR DESCRIPTION
- Created device/info route on the new routing changes from the `staging` branch. Calling the route no longer crashes the server if there are no matches to the API key requested in the database. 
- Created unit test for device/info without calling the other routes. It simply calls mongoose methods directly in the tests to register and delete a temporary device in the database. Let me know if this is what you intended @harsimrat99.