### PR TITLE
Workflow Hotfix

### DIFF
--- a/util/env.js
+++ b/util/env.js
@@ -3,6 +3,7 @@ const dotenv = require('dotenv');
 exports.configure = () => {
   const result = dotenv.config();
   if (result.error) {
+    if (result.error.code === 'ENOENT') return;
     throw result.error;
   }
   return 0;


### PR DESCRIPTION
The new problem with the workflow is because we need to handle the error thrown when no `.env` file is found.