### PR TITLE
Bump minimum Node test version to 14.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     env:


### PR DESCRIPTION
The `fs.rmSync()` method used in `/POST data/blob` was introduced in Node v14. Unless we require compatibility with Node v12, we can remove that version's test check.