### PR TITLE
GET data api request route

### DIFF
--- a/routes/data/GET-data.js
+++ b/routes/data/GET-data.js
@@ -1,5 +1,15 @@
+const Data = require('../../models/data');
+
 module.exports = (app) => {
     app.get('/device/getData', (req, res) => {
-        res.sendStatus(404);
+        if (!req.query.mac) return res.status(400).json({ error: 'No MAC address provided.' });
+        if (!req.query.points) return res.status(400).json({ error: 'Please specify number of data points.' });
+        mac = req.query.mac.replace(/(..)/g, '$1:').slice(0, -1);
+        points = Number(req.query.points);
+        Data.find({ deviceId: mac }).sort({timestamp: -1}).limit(points).exec((err, Data) => {
+            if (err) return res.status(400).json({ error: 'Bad Request' });
+            if (Data == null) return res.status(404).json({ error: 'Not found.' });
+            return res.status(200).json({ Data });
+        })
     });
 };

--- a/test/data_get_test.js
+++ b/test/data_get_test.js
@@ -1,0 +1,55 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const faker = require('faker');
+const uuidApiKey = require('uuid-apikey');
+
+const app = require('../app');
+const Device = require('../models/device');
+const Data = require('../models/data');
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+describe('/GET device/getData', () => {
+  const tempMac = faker.internet.mac();
+  const tempName = faker.internet.userName();
+  const tempTemperature = faker.datatype.number();
+  const tempLocation = {
+    type: "Point",
+    coordinates: [faker.address.latitude(), faker.address.longitude()]
+  };
+  const { uuid, apiKey } = uuidApiKey.create();
+
+  before(() => {
+    // Register a temp device and Post temporary data
+    new Device({
+      deviceId: tempMac,
+      friendlyName: tempName,
+      uuid,
+      apiKey,
+    }).save();
+    new Data({
+        apiKey: apiKey,
+        deviceId: tempMac,
+        temperature: tempTemperature,
+        location: tempLocation
+    }).save();
+  });
+
+  it('it should GET the data', (done) => {
+    chai.request(app)
+      .get(`/device/getData?mac=${tempMac.replace(/:/g, '')}&points=1`)
+      .end((_, res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.Data.location).to.equal(tempLocation);
+        expect(res.Data.temperature).to.equal(tempTemperature);
+      });
+    done();
+  });
+
+  after(() => { 
+    //Delete temp device and temp data
+    Data.deleteOne({ deviceId: tempMac });
+    Device.deleteOne({ deviceId: tempMac }); 
+    });
+});

--- a/test/data_post_test.js
+++ b/test/data_post_test.js
@@ -10,11 +10,14 @@ const Data = require('../models/data');
 const { expect } = chai;
 chai.use(chaiHttp);
 
-describe('/GET data/new', () => {
+describe('/POST data/new', () => {
   const tempMac = faker.internet.mac();
   const tempName = faker.internet.userName();
   const tempTemperature = faker.datatype.number();
-  const tempLocation = faker.datatype.number();
+  const tempLocation = {
+    type: "Point",
+    coordinates: [faker.address.latitude(), faker.address.longitude()]
+  };
   const { uuid, apiKey } = uuidApiKey.create();
 
   before(() => {
@@ -30,7 +33,7 @@ describe('/GET data/new', () => {
   it('it should POST the data', (done) => {
     chai.request(app)
       .post('/data/new')
-      .send({ apiKey: apiKey, deviceId: tempMac, temperature: tempTemperature, location: tempLocation  })
+      .send({ apiKey: apiKey, deviceId: tempMac, temperature: tempTemperature, location: tempLocation })
       .end((_, res) => {
         expect(res.statusCode).to.equal(201);
         Data.findOne({ deviceId: tempMac }, (__, doc) => {


### PR DESCRIPTION
Added the data request route at `/device/getData`. The code works similarly to the `/device/info` route. It requires two URL parameters; the device mac address and the number of data points desired. Mocha testing is also implemented. Closes #15 