### PR TITLE
Fix dependency for workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "aws-sdk": "^2.936.0",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
-        "formidable": "github:node-formidable/formidable",
+        "formidable": "^2.0.0-canary.20200504.1",
         "md5": "^2.3.0",
         "mongoose": "^5.12.13",
         "mqtt": "^4.2.8",
@@ -1940,14 +1940,14 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.0.0-canary.20210330",
-      "resolved": "git+ssh://git@github.com/node-formidable/formidable.git#843ac843053d7f349d69233bb7ab7a45bd2be203",
-      "license": "MIT",
+      "version": "2.0.0-canary.20200504.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.0-canary.20200504.1.tgz",
+      "integrity": "sha512-//FlGY4V1wl5+Q54Gfx8FHErl0tDrRatftGFOgis2IeH8JFs4Ve/r+hubMRfk3gjSyI8VYLg8dWfa1DqfhMdCg==",
       "dependencies": {
         "dezalgo": "1.0.3",
         "hexoid": "1.0.0",
         "once": "1.4.0",
-        "qs": "6.9.3"
+        "qs": "^6.9.3"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -6334,13 +6334,14 @@
       }
     },
     "formidable": {
-      "version": "git+ssh://git@github.com/node-formidable/formidable.git#843ac843053d7f349d69233bb7ab7a45bd2be203",
-      "from": "formidable@github:node-formidable/formidable",
+      "version": "2.0.0-canary.20200504.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.0-canary.20200504.1.tgz",
+      "integrity": "sha512-//FlGY4V1wl5+Q54Gfx8FHErl0tDrRatftGFOgis2IeH8JFs4Ve/r+hubMRfk3gjSyI8VYLg8dWfa1DqfhMdCg==",
       "requires": {
         "dezalgo": "1.0.3",
         "hexoid": "1.0.0",
         "once": "1.4.0",
-        "qs": "6.9.3"
+        "qs": "^6.9.3"
       },
       "dependencies": {
         "qs": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "aws-sdk": "^2.936.0",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "formidable": "github:node-formidable/formidable",
+    "formidable": "^2.0.0-canary.20200504.1",
     "md5": "^2.3.0",
     "mongoose": "^5.12.13",
     "mqtt": "^4.2.8",


### PR DESCRIPTION
Switch `node-formidable` to install from the npm registry instead of their GitHub repo. This was holding up workflow checks on the `npm ci` step.