### PR TITLE
Remove colon/dash use in MAC addresses

### DIFF
--- a/routes/device/GET-info.js
+++ b/routes/device/GET-info.js
@@ -4,7 +4,7 @@ module.exports = (app) => {
   app.get('/device/info', (req, res) => {
     if (!req.query.mac) return res.status(400).json({ error: 'No MAC address provided.' });
     // Take MAC address with no symbols as query parameter and reformat with colons
-    const mac = req.query.mac.replace(/(..)/g, '$1:').slice(0, -1);
+    const mac = req.query.mac.toLowerCase();
     Device.findOne({ deviceId: mac }, 'friendlyName', (err, foundDevice) => {
       if (err) return res.status(400).json({ error: 'Bad Request' });
       if (foundDevice == null) return res.status(404).json({ error: 'No device found.' });

--- a/routes/device/POST-register.js
+++ b/routes/device/POST-register.js
@@ -9,11 +9,11 @@ module.exports = (app) => {
     // the device information is stored
     // OUTPUT: success/failure
     const { deviceId, friendlyName } = req.body;
-    if (!deviceId || !deviceId.match(/^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/) || !friendlyName) return res.status(400).json({ error: 'Bad Request' });
+    if (!deviceId || !deviceId.match(/([0-9A-Fa-f]{2}){6}/) || !friendlyName) return res.status(400).json({ error: 'Bad Request' });
     const { uuid, apiKey } = uuidApiKey.create();
 
     new Device({
-      deviceId: deviceId.replace(/[:-]/, '').toLowerCase(),
+      deviceId: deviceId.toLowerCase(),
       friendlyName,
       uuid,
       apiKey,

--- a/routes/device/POST-register.js
+++ b/routes/device/POST-register.js
@@ -13,7 +13,7 @@ module.exports = (app) => {
     const { uuid, apiKey } = uuidApiKey.create();
 
     new Device({
-      deviceId,
+      deviceId: deviceId.replace(/[:-]/, '').toLowerCase(),
       friendlyName,
       uuid,
       apiKey,

--- a/routes/device/POST-unregister.js
+++ b/routes/device/POST-unregister.js
@@ -6,7 +6,7 @@ module.exports = (app) => {
     // INPUT: deviceid (mac address)
     // Deletes the device associated with this deviceid (mac address)
     // OUTPUT: Success/failure
-    const { deviceId } = req.body;
+    const deviceId = req.body.deviceId.toLowerCase();
 
     Device.findOneAndDelete({ deviceId }, (err, foundDevice) => {
       if (err) return res.status(400).json({ error: 'Bad Request' });

--- a/test/device_info_test.js
+++ b/test/device_info_test.js
@@ -10,7 +10,7 @@ const { expect } = chai;
 chai.use(chaiHttp);
 
 describe('/GET device/info', () => {
-  const tempMac = faker.internet.mac();
+  const tempMac = faker.internet.mac().replace(/:/g, '');
   const tempName = faker.internet.userName();
   const { uuid, apiKey } = uuidApiKey.create();
 
@@ -26,7 +26,7 @@ describe('/GET device/info', () => {
 
   it('it should GET the device information', (done) => {
     chai.request(app)
-      .get(`/device/info?mac=${tempMac.replace(/:/g, '')}`)
+      .get(`/device/info?mac=${tempMac}`)
       .end((_, res) => {
         expect(res.statusCode).to.equal(200);
         expect(res.body.friendlyName).to.equal(tempName);

--- a/test/device_register_test.js
+++ b/test/device_register_test.js
@@ -9,7 +9,7 @@ const { expect } = chai;
 chai.use(chaiHttp);
 
 describe('/POST device/register', () => {
-  const tempMac = faker.internet.mac();
+  const tempMac = faker.internet.mac().replace(/:/g, '');
   it('it should POST the information', (done) => {
     chai.request(app)
       .post('/device/register')

--- a/test/device_unregister_test.js
+++ b/test/device_unregister_test.js
@@ -9,7 +9,7 @@ const { expect } = chai;
 chai.use(chaiHttp);
 
 describe('/POST device/unregister', () => {
-  const tempMac = faker.internet.mac();
+  const tempMac = faker.internet.mac().replace(/:/g, '');
 
   before((done) => {
     // Register temporary device


### PR DESCRIPTION
- `GET register` now expects a MAC address with no symbols.
- Remove colons in `faker`-generated MAC addresses in Mocha tests.

Resolves #32 