### PR TITLE
Add CORS support

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,11 +2,14 @@ require('./util/env').configure(); // configure the environment variables
 require('./util/mongodb'); // configure mongoose db connection
 require('./util/aedes'); // configure MQTT broker
 const express = require('express');
+const cors = require('cors');
 
 // Express config
 const app = express();
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
+// TODO add production check for TLS or not
+app.use(cors({ origin: `http://localhost:${process.env.WEBAPP_PORT}` }));
 
 // Dynamic route loading
 require('./util/router').boot(app);

--- a/app.js
+++ b/app.js
@@ -10,12 +10,12 @@ const fs = require('fs');
 const app = express();
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
+app.use(cors({ origin: `${(process.env.NODE_ENV === 'production') ? 'https' : 'http'}://localhost:${process.env.WEBAPP_PORT || 3000}` }));
 
 // Dynamic route loading
 require('./util/router').boot(app);
 
 if (process.env.NODE_ENV === 'production') {
-  app.use(cors({ origin: `https://localhost:${process.env.WEBAPP_PORT}` }));
   const options = {
     key: fs.readFileSync(process.env.HTTPS_SERVER_KEY_PATH),
     cert: fs.readFileSync(process.env.HTTPS_SERVER_CERT_PATH),
@@ -33,7 +33,6 @@ if (process.env.NODE_ENV === 'production') {
     res.end();
   }).listen(process.env.HTTP_PORT || 80);
 } else {
-  app.use(cors({ origin: `http://localhost:${process.env.WEBAPP_PORT}` }));
   server.createServer(app).listen(process.env.HTTP_PORT || 80,
     function listen() {
       console.log(`HTTP server started and listening on port ${this.address().port}`);

--- a/app.js
+++ b/app.js
@@ -1,21 +1,42 @@
 require('./util/env').configure(); // configure the environment variables
 require('./util/mongodb'); // configure mongoose db connection
 require('./util/aedes'); // configure MQTT broker
+const server = (process.env.NODE_ENV === 'production') ? require('https') : require('http');
 const express = require('express');
 const cors = require('cors');
+const fs = require('fs');
 
 // Express config
 const app = express();
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
-// TODO add production check for TLS or not
-app.use(cors({ origin: `http://localhost:${process.env.WEBAPP_PORT}` }));
 
 // Dynamic route loading
 require('./util/router').boot(app);
 
-app.listen(process.env.PORT || 3000, function listen() {
-  console.log(`Express server started and listening on port ${this.address().port}`);
-});
+if (process.env.NODE_ENV === 'production') {
+  app.use(cors({ origin: `https://localhost:${process.env.WEBAPP_PORT}` }));
+  const options = {
+    key: fs.readFileSync(process.env.HTTPS_SERVER_KEY_PATH),
+    cert: fs.readFileSync(process.env.HTTPS_SERVER_CERT_PATH),
+    ca: fs.readFileSync(process.env.HTTPS_SERVER_CA_PATH),
+  };
 
-if (!process.env.PRODUCTION) module.exports = app; // export for testing
+  server.createServer(options, app).listen(process.env.HTTPS_PORT || 443,
+    function listen() {
+      console.log(`HTTPS server started and listening on port ${this.address().port}`);
+    });
+
+  // eslint-disable-next-line global-require
+  require('http').createServer((req, res) => {
+    res.writeHead(301, { Location: `https://${req.headers.host}${req.url}` });
+    res.end();
+  }).listen(process.env.HTTP_PORT || 80);
+} else {
+  app.use(cors({ origin: `http://localhost:${process.env.WEBAPP_PORT}` }));
+  server.createServer(app).listen(process.env.HTTP_PORT || 80,
+    function listen() {
+      console.log(`HTTP server started and listening on port ${this.address().port}`);
+    });
+  module.exports = app; // export for testing
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "aedes": "^0.46.0",
         "aws-sdk": "^2.936.0",
+        "cors": "^2.8.5",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "formidable": "^2.0.0-canary.20200504.1",
@@ -1014,6 +1015,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3144,6 +3157,14 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5595,6 +5616,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7248,6 +7278,11 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.10.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "aedes": "^0.46.0",
         "aws-sdk": "^2.936.0",
+        "cors": "^2.8.5",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "formidable": "github:node-formidable/formidable",
@@ -1013,6 +1014,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3143,6 +3156,14 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5594,6 +5615,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7246,6 +7276,11 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.10.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "aedes": "^0.46.0",
     "aws-sdk": "^2.936.0",
+    "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "formidable": "^2.0.0-canary.20200504.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "aedes": "^0.46.0",
     "aws-sdk": "^2.936.0",
+    "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "formidable": "github:node-formidable/formidable",

--- a/util/aedes.js
+++ b/util/aedes.js
@@ -1,5 +1,5 @@
 const aedes = require('aedes')();
-const server = (process.env.PRODUCTION) ? require('tls') : require('net');
+const server = (process.env.NODE_ENV === 'production') ? require('tls') : require('net');
 const mqtt = require('mqtt');
 const fs = require('fs');
 
@@ -11,7 +11,7 @@ function eventHandler(client) {
   });
 }
 
-if (process.env.PRODUCTION) {
+if (process.env.NODE_ENV === 'production') {
   const options = {
     key: fs.readFileSync(process.env.MQTT_SERVER_KEY_PATH),
     cert: fs.readFileSync(process.env.MQTT_SERVER_CERT_PATH),


### PR DESCRIPTION
- Add a production check for deciding whether to use HTTPS or HTTP.
- Add CORS middleware that will accept requests from the localhost on port `3000`. This is the port the webapp should run on.
- Have the HTTP server use `80` as the default port.
- Have the HTTPS server use `443` as the default port.

Resolves https://github.com/CloudClub-uoft/iot-webapp/issues/5