### PR TITLE
Device self-registration route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@
 # production
 /build
 
+# tls
+*.crt
+*.key
+*.pem
+*.der
+
 # misc
 .DS_Store
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
         "cookie-parser": "^1.4.5",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
-        "jsonwebtoken": "^8.5.1",
         "formidable": "^2.0.0-canary.20200504.1",
+        "jsonwebtoken": "^8.5.1",
         "md5": "^2.3.0",
         "mongoose": "^5.12.13",
         "mqtt": "^4.2.8",
@@ -7264,7 +7264,7 @@
     },
     "formidable": {
       "version": "git+ssh://git@github.com/node-formidable/formidable.git#3d429e00a4e343cbce94440c9f2a9fcc1f03a8bd",
-      "from": "formidable@github:node-formidable/formidable",
+      "from": "formidable@^2.0.0-canary.20200504.1",
       "requires": {
         "dezalgo": "1.0.3",
         "hexoid": "1.0.0",

--- a/routes/auth/GET-cert.js
+++ b/routes/auth/GET-cert.js
@@ -1,7 +1,7 @@
 const jwt = require('jsonwebtoken');
-const forge = require('node-forge');
-const fs = require('fs');
 const Archiver = require('archiver');
+
+const genCert = require('../../util/genCert');
 
 module.exports = (app) => {
   app.get('/auth/cert', (req, res) => {
@@ -18,49 +18,7 @@ module.exports = (app) => {
       return res.status(400).json({ Error: 'Bad Request 400' });
     }
 
-    const caCert = forge.pki.certificateFromPem(fs.readFileSync(process.env.MQTT_SERVER_CA_PATH));
-    const caKey = forge.pki.privateKeyFromPem(fs.readFileSync(process.env.MQTT_SERVER_KEY_PATH));
-
-    const clientKeys = forge.pki.rsa.generateKeyPair(4096);
-    const clientCert = forge.pki.createCertificate();
-    clientCert.publicKey = clientKeys.publicKey;
-    clientCert.serialNumber = '01';
-    clientCert.validity.notBefore = new Date();
-    clientCert.validity.notAfter = new Date();
-    clientCert.validity.notAfter.setDate(clientCert.validity.notBefore.getDate() + 365);
-
-    const attributes = [{
-      name: 'commonName',
-      value: 'IoT Device',
-    }, {
-      name: 'countryName',
-      value: 'CA',
-    }, {
-      name: 'localityName',
-      value: 'Toronto',
-    }, {
-      name: 'stateOrProvinceName',
-      value: 'ON',
-    }, {
-      name: 'organizationName',
-      value: 'CloudClub',
-    }, {
-      name: 'organizationalUnitName',
-      value: 'IoT-Project',
-    }, {
-      name: 'emailAddress',
-      value: payload.email,
-    }];
-
-    clientCert.setSubject(attributes);
-    clientCert.setIssuer(caCert.subject.attributes);
-
-    clientCert.sign(caKey, forge.md.sha256.create());
-
-    const pem = {
-      privateKey: forge.pki.privateKeyToPem(clientKeys.privateKey),
-      certificate: forge.pki.certificateToPem(clientCert),
-    };
+    const pem = genCert(payload.email, 'pem');
 
     if (download) {
       res.attachment('auth.zip');

--- a/routes/auth/POST-login.js
+++ b/routes/auth/POST-login.js
@@ -1,38 +1,18 @@
-const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 
-const db = require('../../util/mysql');
+const login = require('../../util/login');
 
 module.exports = (app) => {
   app.post('/auth/login', (req, res) => {
-    const { email, password } = req.body;
-    if (email === undefined || password === undefined) {
-      return res.status(400).json({ error: 'Missing fields, check our API docs at cloudclub.ca/api' });
-    }
-    db.query(`SELECT * FROM logins WHERE email='${email}'`, (err1, result1) => {
-      if (err1) return res.status(500).json({ error: 'Internal Server Error 500' });
-      if (result1.length === 1) {
-        bcrypt.compare(password, result1[0].password, (err2, result2) => {
-          if (err2) return res.status(500).json({ error: 'Internal Server Error 500' });
+    login(req, res, (email) => {
+      const jwtExpiry = 24 * 60 * 60; // 1 day in seconds
+      const token = jwt.sign({ email }, process.env.JWT_KEY, {
+        algorithm: 'HS256',
+        expiresIn: jwtExpiry,
+      });
 
-          if (result2) {
-            const jwtExpiry = 24 * 60 * 60; // 1 day in seconds
-            const token = jwt.sign({ email }, process.env.JWT_KEY, {
-              algorithm: 'HS256',
-              expiresIn: jwtExpiry,
-            });
-
-            res.cookie('token', token, { maxAge: jwtExpiry * 1000 });
-            return res.status(200).json({ message: 'Login Successful!' });
-          }
-          return res.status(401).json({ error: 'Password incorrect.' });
-        });
-      } else if (result1.length === 0) {
-        return res.status(401).json({ error: 'Email not found.' });
-      } else {
-        console.log(`ERROR: Duplicate login entry under email '${email}'`);
-        return res.status(500).json({ error: 'Internal Server Error 500' });
-      }
+      res.cookie('token', token, { maxAge: jwtExpiry * 1000 });
+      return res.status(200).json({ message: 'Login Successful!' });
     });
   });
 };

--- a/routes/device/GET-cert.js
+++ b/routes/device/GET-cert.js
@@ -1,0 +1,11 @@
+const login = require('../../util/login');
+const genCert = require('../../util/genCert');
+
+module.exports = (app) => {
+  app.get('/device/cert', (req, res) => {
+    login(req, res, (email) => {
+      const der = genCert(email, 'der');
+      return res.status(200).json(der);
+    });
+  });
+};

--- a/routes/device/POST-cert.js
+++ b/routes/device/POST-cert.js
@@ -2,7 +2,7 @@ const login = require('../../util/login');
 const genCert = require('../../util/genCert');
 
 module.exports = (app) => {
-  app.get('/device/cert', (req, res) => {
+  app.post('/device/cert', (req, res) => {
     login(req, res, (email) => {
       const der = genCert(email, 'der');
       return res.status(200).json(der);

--- a/test/auth_cert_test.js
+++ b/test/auth_cert_test.js
@@ -11,37 +11,11 @@ const { expect } = chai;
 chai.use(chaiHttp);
 
 describe('/GET auth/cert', () => {
-  process.env.JWT_KEY = 'test';
+  const caCert = forge.pki.certificateFromPem(fs.readFileSync(process.env.MQTT_SERVER_CA_PATH));
   const email = faker.internet.email();
   const token = jwt.sign({ email }, process.env.JWT_KEY, {
     algorithm: 'HS256',
     expiresIn: 60,
-  });
-  const caCert = forge.pki.createCertificate();
-
-  before(() => {
-    const caKeys = forge.pki.rsa.generateKeyPair(4096);
-    caCert.publicKey = caKeys.publicKey;
-    caCert.serialNumber = '01';
-    caCert.validity.notBefore = new Date();
-    caCert.validity.notAfter = new Date();
-    caCert.validity.notAfter.setDate(caCert.validity.notBefore.getDate() + 365);
-
-    const attributes = [{ name: 'countryName', value: 'CA' }];
-
-    caCert.setSubject(attributes);
-    caCert.setIssuer(attributes);
-    caCert.sign(caKeys.privateKey, forge.md.sha256.create());
-
-    const pem = {
-      privateKey: forge.pki.privateKeyToPem(caKeys.privateKey),
-      certificate: forge.pki.certificateToPem(caCert),
-    };
-
-    fs.writeFileSync('testKey.key', pem.privateKey);
-    fs.writeFileSync('testCert.crt', pem.certificate);
-    process.env.MQTT_SERVER_KEY_PATH = 'testKey.key';
-    process.env.MQTT_SERVER_CA_PATH = 'testCert.crt';
   });
 
   it('it should authenticate the user and return a client certificate and key', (done) => {
@@ -55,10 +29,5 @@ describe('/GET auth/cert', () => {
         expect(caCert.verify(cert)).to.equal(true);
       });
     done();
-  });
-
-  after(() => {
-    fs.unlinkSync('testKey.key');
-    fs.unlinkSync('testCert.crt');
   });
 });

--- a/test/device_cert_test.js
+++ b/test/device_cert_test.js
@@ -1,0 +1,43 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const faker = require('faker');
+const bcrypt = require('bcrypt');
+const forge = require('node-forge');
+const fs = require('fs');
+
+const app = require('../app');
+const db = require('../util/mysql');
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+describe('/POST device/cert', () => {
+  const caCert = forge.pki.certificateFromPem(fs.readFileSync(process.env.MQTT_SERVER_CA_PATH));
+  const email = faker.internet.email();
+  const password = faker.internet.password();
+  const first = faker.name.firstName();
+  const last = faker.name.lastName();
+
+  before((done) => {
+    bcrypt.hash(password, 5, (_, hash) => {
+      db.query(`INSERT INTO logins (\`first-name\`, \`last-name\`, email, password) VALUES ('${first}', '${last}', '${email}', '${hash}')`, done);
+    });
+  });
+
+  it('it should authenticate the device and return a client certificate and key', (done) => {
+    chai.request(app)
+      .post('/device/cert')
+      .send({ email, password })
+      .end((_, res) => {
+        expect(res).to.have.status(200);
+        forge.pki.privateKeyFromAsn1(forge.asn1.fromDer(res.body.privateKey.data));
+        const cert = forge.pki.certificateFromAsn1(forge.asn1.fromDer(res.body.certificate.data));
+        expect(caCert.verify(cert)).to.equal(true);
+        done();
+      });
+  });
+
+  after((done) => {
+    db.query(`DELETE FROM logins WHERE email='${email}'`, done);
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,39 @@
+const forge = require('node-forge');
+const fs = require('fs');
+
+exports.mochaHooks = {
+  beforeAll() {
+    process.env.JWT_KEY = 'test';
+
+    // TLS server certificates setup
+    const caCert = forge.pki.createCertificate();
+    const caKeys = forge.pki.rsa.generateKeyPair(4096);
+    caCert.publicKey = caKeys.publicKey;
+    caCert.serialNumber = '01';
+    caCert.validity.notBefore = new Date();
+    caCert.validity.notAfter = new Date();
+    caCert.validity.notAfter.setDate(caCert.validity.notBefore.getDate() + 365);
+
+    const attributes = [{ name: 'countryName', value: 'CA' }];
+
+    caCert.setSubject(attributes);
+    caCert.setIssuer(attributes);
+    caCert.sign(caKeys.privateKey, forge.md.sha256.create());
+
+    const pem = {
+      privateKey: forge.pki.privateKeyToPem(caKeys.privateKey),
+      certificate: forge.pki.certificateToPem(caCert),
+    };
+
+    fs.writeFileSync('testKey.key', pem.privateKey);
+    fs.writeFileSync('testCert.crt', pem.certificate);
+    process.env.MQTT_SERVER_KEY_PATH = 'testKey.key';
+    process.env.MQTT_SERVER_CA_PATH = 'testCert.crt';
+  },
+
+  afterAll() {
+    // TLS server certificates cleanup
+    fs.unlinkSync('testKey.key');
+    fs.unlinkSync('testCert.crt');
+  },
+};

--- a/util/genCert.js
+++ b/util/genCert.js
@@ -1,0 +1,62 @@
+const forge = require('node-forge');
+const fs = require('fs');
+
+module.exports = (email, format) => {
+  const caCert = forge.pki.certificateFromPem(fs.readFileSync(process.env.MQTT_SERVER_CA_PATH));
+  const caKey = forge.pki.privateKeyFromPem(fs.readFileSync(process.env.MQTT_SERVER_KEY_PATH));
+
+  const clientKeys = forge.pki.rsa.generateKeyPair(4096);
+  const clientCert = forge.pki.createCertificate();
+  clientCert.publicKey = clientKeys.publicKey;
+  clientCert.serialNumber = '01';
+  clientCert.validity.notBefore = new Date();
+  clientCert.validity.notAfter = new Date();
+  clientCert.validity.notAfter.setDate(clientCert.validity.notBefore.getDate() + 365);
+
+  const attributes = [{
+    name: 'commonName',
+    value: 'IoT Device',
+  }, {
+    name: 'countryName',
+    value: 'CA',
+  }, {
+    name: 'localityName',
+    value: 'Toronto',
+  }, {
+    name: 'stateOrProvinceName',
+    value: 'ON',
+  }, {
+    name: 'organizationName',
+    value: 'CloudClub',
+  }, {
+    name: 'organizationalUnitName',
+    value: 'IoT-Project',
+  }, {
+    name: 'emailAddress',
+    value: email,
+  }];
+
+  clientCert.setSubject(attributes);
+  clientCert.setIssuer(caCert.subject.attributes);
+
+  clientCert.sign(caKey, forge.md.sha256.create());
+
+  let privateKey;
+  let certificate;
+  switch (format) {
+    case 'der':
+      privateKey = forge.asn1.toDer(forge.pki.privateKeyToAsn1(clientKeys.privateKey));
+      certificate = forge.asn1.toDer(forge.pki.certificateToAsn1(clientCert));
+      break;
+    case 'pem':
+    default:
+      privateKey = forge.pki.privateKeyToPem(clientKeys.privateKey);
+      certificate = forge.pki.certificateToPem(clientCert);
+  }
+
+  const keyCert = {
+    privateKey,
+    certificate,
+  };
+  return keyCert;
+};

--- a/util/login.js
+++ b/util/login.js
@@ -1,0 +1,25 @@
+const bcrypt = require('bcrypt');
+
+const db = require('./mysql');
+
+module.exports = (req, res, callback) => {
+  const { email, password } = req.body;
+  if (email === undefined || password === undefined) {
+    return res.status(400).json({ error: 'Missing fields, check our API docs at cloudclub.ca/api' });
+  }
+  db.query(`SELECT * FROM logins WHERE email='${email}'`, (err1, result1) => {
+    if (err1) return res.status(500).json({ error: 'Internal Server Error 500' });
+    if (result1.length === 1) {
+      bcrypt.compare(password, result1[0].password, (err2, result2) => {
+        if (err2) return res.status(500).json({ error: 'Internal Server Error 500' });
+        if (result2) callback(email);
+        if (!res.headersSent) res.status(401).json({ error: 'Password incorrect.' });
+      });
+    } else if (result1.length === 0) {
+      return res.status(401).json({ error: 'Email not found.' });
+    } else {
+      console.log(`ERROR: Duplicate login entry under email '${email}'`);
+      return res.status(500).json({ error: 'Internal Server Error 500' });
+    }
+  });
+};


### PR DESCRIPTION
- Moves certificate generation into a `util/genCert.js` module.
  - `genCert()` takes a mandatory email string and an optional output format, either `'pem'` (default) or `'der'` (binary for devices).
    - `genCert('test@mail.com', 'der')`
  - Returns an object with the `privateKey` and `certificate` properties.
- Moves login authentication into a `util/login.js` module.
  - Takes the `req` request, `res` response, and a callback to execute on successful login, which will contain the email of the user.
    - `login(req, res, (email) => { // do something }`
  - Will retrieve login credentials from a POST request body.
- Implements a `device/cert` POST route for a device to request a certificate for themselves.
  - Expects an `email` and `password`, returns a JSON object with DER-format private key and certificate.

Will change `login.js` into a middleware in a subsequent PR.

Closes #41 