### PR TITLE
Require Authorization for /device/info

### DIFF
--- a/routes/device/GET-info.js
+++ b/routes/device/GET-info.js
@@ -1,7 +1,8 @@
 const Device = require('../../models/device');
+const jwtVerify = require('../../middleware/jwtVerify');
 
 module.exports = (app) => {
-  app.get('/device/info', (req, res) => {
+  app.get('/device/info', jwtVerify, (req, res) => {
     if (!req.query.mac) return res.status(400).json({ error: 'No MAC address provided.' });
     // Take MAC address with no symbols as query parameter and reformat with colons
     const mac = req.query.mac.toLowerCase();

--- a/test/device_info_test.js
+++ b/test/device_info_test.js
@@ -1,6 +1,7 @@
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 const faker = require('faker');
+const jwt = require('jsonwebtoken');
 
 const app = require('../app');
 const Device = require('../models/device');
@@ -11,6 +12,11 @@ chai.use(chaiHttp);
 describe('/GET device/info', () => {
   const tempMac = faker.internet.mac().replace(/:/g, '');
   const tempName = faker.internet.userName();
+  const email = faker.internet.email();
+  const token = jwt.sign({ email }, process.env.JWT_KEY, {
+    algorithm: 'HS256',
+    expiresIn: 60,
+  });
 
   before((done) => {
     // Register a temp device
@@ -23,6 +29,7 @@ describe('/GET device/info', () => {
   it('it should GET the device information', (done) => {
     chai.request(app)
       .get(`/device/info?mac=${tempMac}`)
+      .set('Cookie', `token=${token}`)
       .end((_, res) => {
         expect(res.statusCode).to.equal(200);
         expect(res.body.friendlyName).to.equal(tempName);


### PR DESCRIPTION
Closes #64
Uses the jwtVerify middleware to prevent access unless a valid jwt is presented. Updates the test case to send a valid jwt in its request