### PR TITLE
/device/getDevices route for Listing Devices

### DIFF
--- a/routes/device/GET-userDevices.js
+++ b/routes/device/GET-userDevices.js
@@ -1,0 +1,13 @@
+const jwtVerify = require('../../middleware/jwtVerify');
+const Device = require('../../models/device');
+
+module.exports = (app) => {
+  app.get('/device/userDevices', jwtVerify, (req, res) => {
+    const userEmail = res.locals.jwtPayload.email;
+    Device.find({ userEmail }).sort({ timestamp: -1 }).exec((err, userDevices) => {
+      if (err) return res.status(400).json({ error: 'Bad Request' });
+      if (userDevices == null) return res.status(404).json({ error: 'No Devices Registered.' });
+      return res.status(200).json({ userDevices });
+    });
+  });
+};

--- a/test/data_getData_test.js
+++ b/test/data_getData_test.js
@@ -2,7 +2,6 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const faker = require('faker');
 const jwt = require('jsonwebtoken');
-
 const { deviceApp } = require('../app');
 const Device = require('../models/device');
 const Data = require('../models/data');
@@ -31,6 +30,7 @@ describe('/GET device/data/getData', function test() {
     new Device({
       deviceId: tempMac,
       friendlyName: tempName,
+      userEmail: email,
     }).save().then(() => {
       new Data({
         deviceId: tempMac,

--- a/test/device_info_test.js
+++ b/test/device_info_test.js
@@ -13,13 +13,14 @@ describe('/GET device/info', () => {
   const tempMac = faker.internet.mac().replace(/:/g, '');
   const tempName = faker.internet.userName();
   const email = faker.internet.email();
-  const token = jwt.sign({ email }, process.env.JWT_KEY, {
-    algorithm: 'HS256',
-    expiresIn: 60,
-  });
+  let token;
 
   before((done) => {
     // Register a temp device
+    token = jwt.sign({ email }, process.env.JWT_KEY, {
+      algorithm: 'HS256',
+      expiresIn: 60,
+    });
     new Device({
       deviceId: tempMac,
       friendlyName: tempName,
@@ -37,6 +38,5 @@ describe('/GET device/info', () => {
         done();
       });
   });
-
   after((done) => { Device.deleteOne({ deviceId: tempMac }).then(() => done()); });
 });

--- a/test/device_register_test.js
+++ b/test/device_register_test.js
@@ -2,7 +2,6 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const faker = require('faker');
 const jwt = require('jsonwebtoken');
-
 const { deviceApp } = require('../app');
 const Device = require('../models/device');
 

--- a/test/device_userDevices_test.js
+++ b/test/device_userDevices_test.js
@@ -1,0 +1,40 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const faker = require('faker');
+const jwt = require('jsonwebtoken');
+const { deviceApp } = require('../app');
+const Device = require('../models/device');
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+describe('/GET device/userDevices', () => {
+  const tempMac = faker.internet.mac().replace(/:/g, '');
+  const tempName = faker.internet.userName();
+  const email = faker.internet.email();
+  let token;
+  before((done) => {
+    // Register a temp device
+    token = jwt.sign({ email }, process.env.JWT_KEY, {
+      algorithm: 'HS256',
+      expiresIn: 60,
+    });
+    new Device({
+      deviceId: tempMac,
+      friendlyName: tempName,
+      userEmail: email,
+    }).save().then(() => done());
+  });
+
+  it('it should GET the registered devices by the user', (done) => {
+    chai.request(deviceApp)
+      .get('/device/userDevices')
+      .set('Cookie', `token=${token}`)
+      .end((_, res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body.userDevices[0].friendlyName).to.equal(tempName);
+        done();
+      });
+  });
+  after((done) => { Device.deleteOne({ deviceId: tempMac }).then(() => done()); });
+});


### PR DESCRIPTION
Addresses #53 requesting for a route to list all devices registered by a logged in user. The route was created on the device app at /device/getDevices. Nothing required to send in the request object. I also created the test for this route and fixed some other non-functioning tests.